### PR TITLE
Mark wheels of acme-tiny as universal

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[wheel]
+universal=True


### PR DESCRIPTION
Ensure that wheels created from the acme-tiny source are marked as universal. This avoids having to pass this to `pip wheel` by hand.
